### PR TITLE
Fixed admin page

### DIFF
--- a/dillo/application/modules/admin/__init__.py
+++ b/dillo/application/modules/admin/__init__.py
@@ -96,7 +96,7 @@ class CustomAdminIndexView(admin.AdminIndexView):
     def index(self):
         settings_list = []
         for setting_name in ['logo_alt', 'title', 'tagline', 'title_html',
-            'footer', 'credits']:
+            'footer', 'credits', 'keywords', 'twitter_username']:
             setting = Setting.query.filter_by(name=setting_name).first()
             settings_list.append((setting_name, setting.value))
         settings_multi_dict = MultiDict(settings_list)
@@ -134,6 +134,10 @@ class CustomAdminIndexView(admin.AdminIndexView):
             footer.value = form_settings.footer.data
             credits = Setting.query.filter_by(name='credits').first()
             credits.value = form_settings.credits.data
+            keywords = Setting.query.filter_by(name='keywords').first()
+            keywords.value = form_settings.keywords.data
+            twitter_username = Setting.query.filter_gy(name='twitter_username').first()
+            twitter_username = form_settings.twitter_username.data
             db.session.commit()
             # Reload the settings
             load_settings()

--- a/dillo/application/modules/admin/forms.py
+++ b/dillo/application/modules/admin/forms.py
@@ -12,3 +12,5 @@ class FormSettings(Form):
     tagline = StringField('Tagline')
     footer = TextAreaField('Footer')
     credits = StringField('Site credits')
+    keywords = StringField('Keywords')
+    twitter_username = StringField('Twitter Username')


### PR DESCRIPTION
The page was erroring out on the keywords and twitter_username fields. The form was looking for them, but they weren't entered in the database.