### PR TITLE
Fix: "On creation, make default vote to 1 (self)"

### DIFF
--- a/dillo/posts/eve_hooks.py
+++ b/dillo/posts/eve_hooks.py
@@ -111,7 +111,7 @@ def set_defaults(item):
     # this happens, we can remove most of the values here and set hot using 0 for default positive
     # and negative ratings.
     item['properties']['content'] = ''
-    item['properties']['rating_positive'] = 0
+    item['properties']['rating_positive'] = 1
     item['properties']['rating_negative'] = 0
     item['properties']['status'] = 'pending'
     update_hot(item)

--- a/dillo/posts/rating.py
+++ b/dillo/posts/rating.py
@@ -18,6 +18,14 @@ def patch_post(node_id, patch):
     assert_is_valid_patch(node_id, patch)
     user_id = authentication.current_user_id()
 
+    nodes_coll = current_app.data.driver.db['nodes']
+    node_user_id = nodes_coll.find_one({'_id': node_id },
+                                       projection={'user': 1})
+
+    # we don't allow the user to down/upvote their own posts.
+    if user_id == node_user_id:
+        return abort(403)
+
     if patch['op'] in COMMENT_VOTING_OPS:
         result, node = vote_comment(user_id, node_id, patch)
         # Fetch the full node for reindexing


### PR DESCRIPTION
We prevent users to change the rating of their own posts.

Missing: Hide up/down from UI ( @venomgfx can you do it?)