### PR TITLE
A new file for semi-static placeholder of strings to be translated

### DIFF
--- a/dillo/translations.py
+++ b/dillo/translations.py
@@ -1,0 +1,9 @@
+# Placeholders for translation strings
+from flask_babel gettext as _
+
+# Translation of community summaries.
+communities = {
+    _('Community-driven Blender news'),
+    _('Comunidad de Habla Hispana'),
+    _('Ideas for Blender'),
+}

--- a/src/templates/dillo/index.pug
+++ b/src/templates/dillo/index.pug
@@ -162,7 +162,7 @@ li
 						a(href="{{ url_for('posts.index', community_url=project.url) }}")
 							| {{ project.name }}
 						a.beta(href="https://blender.community/c/today/sWbbbc/announcing-blender-community") BETA
-					.summary {{ project.summary }}
+					.summary {{ _( project.summary ) }}
 
 					| {% if project.extension_props.dillo %}
 

--- a/src/templates/dillo/macros/_communities.pug
+++ b/src/templates/dillo/macros/_communities.pug
@@ -15,7 +15,7 @@ ul
 
 			.d-communities-info
 				span.title {{ community.name }}
-				span.summary {{ community.summary }}
+				span.summary {{ _( community.summary ) }}
 	| {% endfor %}
 
 	li.d-communities-suggest


### PR DESCRIPTION
So this is just to illustrate how we can "cheat" babel into taking strings that are nowhere to be found.

We could have something like config_local.py, or include the communities summary and description in the config_local.py itself. Dunno, food for thought.