### PR TITLE
Fix #50: Cannot `index_nodes_rebuild` and other operations

### DIFF
--- a/dillo/api/posts/hooks.py
+++ b/dillo/api/posts/hooks.py
@@ -49,12 +49,14 @@ def post_count_comments(post_id: ObjectId):
             'localField': '_id',
             'foreignField': 'parent',
             'as': 'comment_doc'}},
-        {'$project': {'count': {'$add': [1, {'$size': 'comment_doc'}]}}},
+        {'$project': {'count': {'$add': [1, {'$size': '$comment_doc'}]}}},
         {'$group': {'_id': None, 'total': {'$sum': '$count'}}}
     ])
 
     try:
         total_size = list(aggr)[0]['total']
+    except IndexError:
+        total_size = 0
     except KeyError:
         total_size = 0
 


### PR DESCRIPTION
Actually this fixes the "Post comments count". And in fact, at least
in my local tests, this fixes users posting comments, which was broken since
the comments count was refactored.

This bug was introduced on 75c35a99ba
I suspect that comments count was never correct in any instance.